### PR TITLE
remove whitespace in header

### DIFF
--- a/lib/fog/radosgw/utils.rb
+++ b/lib/fog/radosgw/utils.rb
@@ -21,13 +21,11 @@ module Fog
       def signature(params, expires)
         headers = params[:headers] || {}
 
-        string_to_sign =
-            <<-DATA
-#{params[:method].to_s.upcase}
-        #{headers['Content-MD5']}
-        #{headers['Content-Type']}
-        #{expires}
-        DATA
+        string_to_sign = [
+          params[:method].to_s.upcase,
+          headers['Content-MD5'],
+          headers['Content-Type'],
+          expires].map(&:to_s).join("\n") + "\n"
 
         amz_headers, canonical_amz_headers = {}, ''
         for key, value in headers


### PR DESCRIPTION
When trying to access radosgw with this gem, I was getting a `SignatureDoesNotMatch` from the gateway. After walking through the S3 [authorization docs](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html#RESTAuthenticationStringToSign), I noticed that there was extra whitespace included in the headers that are signed. This PR removes that extra whitespace so that requests are valid.

:beers:

---

Edit: Can you release these changes in a minor update (v0.0.5)? 
